### PR TITLE
Remove unused ETH Tx volume chart

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -6,7 +6,6 @@ import TelegramFeed from '@/components/TelegramFeed';
 import CryptoPrices from '@/components/CryptoPrices';
 import EconomicIndicators from '@/components/EconomicIndicators';
 import ThemeToggle from '@/components/ThemeToggle';
-import EthTxVolumeChart from '@/components/EthTxVolumeChart';
 
 export default function Dashboard() {
     const [symbol, setSymbol] = useState('HYPE');
@@ -25,7 +24,6 @@ export default function Dashboard() {
                     <div className="space-y-8">
                         <CryptoPrices onSymbolClick={setSymbol} />
                         <EconomicIndicators />
-                        <EthTxVolumeChart />
                     </div>
                     {/* Right Column */}
                     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- remove `EthTxVolumeChart` import from the dashboard
- drop the ETH volume chart element from the dashboard layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68532860feec832ebe251619a7831f17