### PR TITLE
Optimize data fetching

### DIFF
--- a/src/app/api/economic-indicators/route.ts
+++ b/src/app/api/economic-indicators/route.ts
@@ -1,96 +1,12 @@
 import { NextResponse } from 'next/server';
-
-const FRED_API_KEY = process.env.FRED_API_KEY;
-const FRED_API_BASE_URL = 'https://api.stlouisfed.org/fred/series/observations';
-
-interface Indicator {
-  name: string;
-  value: string;
-  date: string;
-}
-
-const SERIES_IDS = {
-  GDP: 'GDP', // Real Gross Domestic Product, Quarterly
-  CPI: 'CPIAUCSL', // Consumer Price Index, Monthly
-  UNEMPLOYMENT: 'UNRATE', // Unemployment Rate, Monthly
-};
-
-async function fetchIndicator(seriesId: string): Promise<{ date: string; value: string } | null> {
-  const url = `${FRED_API_BASE_URL}?series_id=${seriesId}&api_key=${FRED_API_KEY}&file_type=json&limit=1&sort_order=desc`;
-  
-  try {
-    const response = await fetch(url, { next: { revalidate: 3600 * 24 } }); // Revalidate once a day
-    if (!response.ok) {
-      console.error(`Failed to fetch ${seriesId}: ${response.statusText}`);
-      return null;
-    }
-    const data = await response.json();
-    const observation = data.observations?.[0];
-    if (observation) {
-      return {
-        date: observation.date,
-        value: observation.value,
-      };
-    }
-    return null;
-  } catch (error) {
-    console.error(`Error fetching ${seriesId}:`, error);
-    return null;
-  }
-}
-
-async function fetchCpiYearOverYear() {
-    const url = `${FRED_API_BASE_URL}?series_id=${SERIES_IDS.CPI}&api_key=${FRED_API_KEY}&file_type=json&limit=13&sort_order=desc`;
-    try {
-      const response = await fetch(url, { next: { revalidate: 3600 * 24 } });
-      if (!response.ok) return null;
-      const data = await response.json();
-      const observations = data.observations;
-      if (observations && observations.length >= 13) {
-        const currentValue = parseFloat(observations[0].value);
-        const previousValue = parseFloat(observations[12].value);
-        const yoyChange = ((currentValue - previousValue) / previousValue) * 100;
-        return {
-          date: observations[0].date,
-          value: yoyChange.toFixed(1) + '%',
-        };
-      }
-      return null;
-    } catch (error) {
-      console.error(`Error fetching CPI YoY:`, error);
-      return null;
-    }
-}
-
+import { getEconomicIndicators } from '@/lib/economicIndicators';
 
 export async function GET() {
-  if (!FRED_API_KEY) {
-    console.error('FRED_API_KEY is not set.');
-    return NextResponse.json({ error: 'FRED API key not configured' }, { status: 500 });
-  }
-
   try {
-    const [gdpData, cpiData, unemploymentData] = await Promise.all([
-      fetchIndicator(SERIES_IDS.GDP),
-      fetchCpiYearOverYear(),
-      fetchIndicator(SERIES_IDS.UNEMPLOYMENT),
-    ]);
-
-    const indicators: Indicator[] = [];
-    if (gdpData) {
-        const gdpValue = (parseFloat(gdpData.value) / 1000).toFixed(2) + 'T';
-        indicators.push({ name: 'GDP (Quarterly)', value: gdpValue, date: gdpData.date });
-    }
-    if (cpiData) {
-        indicators.push({ name: 'CPI Inflation Rate', value: cpiData.value, date: cpiData.date });
-    }
-    if (unemploymentData) {
-        indicators.push({ name: 'Unemployment Rate', value: unemploymentData.value + '%', date: unemploymentData.date });
-    }
-
+    const indicators = await getEconomicIndicators();
     return NextResponse.json(indicators);
   } catch (error) {
     console.error('Error fetching economic indicators:', error);
     return NextResponse.json({ error: 'Failed to fetch economic indicators' }, { status: 500 });
   }
-} 
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import PriceChart from '@/components/PriceChart';
+import dynamic from 'next/dynamic';
+
+const PriceChart = dynamic(() => import('@/components/PriceChart'), { ssr: false });
 import TelegramFeed from '@/components/TelegramFeed';
 import CryptoPrices from '@/components/CryptoPrices';
 import EconomicIndicators from '@/components/EconomicIndicators';

--- a/src/components/EconomicIndicators.tsx
+++ b/src/components/EconomicIndicators.tsx
@@ -1,52 +1,13 @@
-'use client';
+import { getEconomicIndicators } from '@/lib/economicIndicators';
 
-import { useState, useEffect } from 'react';
-
-interface Indicator {
-  name: string;
-  value: string;
-  date: string;
-}
-
-export default function EconomicIndicators() {
-  const [indicators, setIndicators] = useState<Indicator[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchIndicators = async () => {
-      try {
-        setLoading(true);
-        
-        // Add timeout to prevent hanging requests
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-        
-        const response = await fetch('/api/economic-indicators', {
-          signal: controller.signal
-        });
-        clearTimeout(timeoutId);
-        
-        const data = await response.json();
-        if (response.ok) {
-          setIndicators(data);
-        }
-      } catch {
-        // Silently handle errors - keep console clean
-        // Keep existing data if fetch fails
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchIndicators();
-  }, []);
+export default async function EconomicIndicators() {
+  const indicators = await getEconomicIndicators();
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 transition-colors">
       <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">Economic Indicators</h2>
       <div className="space-y-4">
-        {loading && !indicators.length ? (
-          <p className="text-gray-500 dark:text-gray-400">Loading...</p>
-        ) : (
+        {indicators.length ? (
           indicators.map(indicator => (
             <div key={indicator.name} className="flex justify-between items-baseline">
               <span className="text-gray-700 dark:text-gray-300">{indicator.name}</span>
@@ -56,11 +17,10 @@ export default function EconomicIndicators() {
               </span>
             </div>
           ))
-        )}
-        {!loading && !indicators.length && (
-            <p className="text-gray-500 dark:text-gray-400">No valid upcoming economic events found.</p>
+        ) : (
+          <p className="text-gray-500 dark:text-gray-400">No valid upcoming economic events found.</p>
         )}
       </div>
     </div>
   );
-} 
+}

--- a/src/lib/economicIndicators.ts
+++ b/src/lib/economicIndicators.ts
@@ -1,0 +1,53 @@
+const FRED_API_KEY = process.env.FRED_API_KEY;
+const FRED_API_BASE_URL = 'https://api.stlouisfed.org/fred/series/observations';
+
+export interface Indicator {
+  name: string;
+  value: string;
+  date: string;
+}
+
+async function fetchIndicator(seriesId: string) {
+  const url = `${FRED_API_BASE_URL}?series_id=${seriesId}&api_key=${FRED_API_KEY}&file_type=json&limit=1&sort_order=desc`;
+  const response = await fetch(url, { next: { revalidate: 86400 } });
+  if (!response.ok) return null;
+  const data = await response.json();
+  const obs = data.observations?.[0];
+  return obs ? { date: obs.date, value: obs.value } : null;
+}
+
+async function fetchCpiYearOverYear() {
+  const url = `${FRED_API_BASE_URL}?series_id=CPIAUCSL&api_key=${FRED_API_KEY}&file_type=json&limit=13&sort_order=desc`;
+  const response = await fetch(url, { next: { revalidate: 86400 } });
+  if (!response.ok) return null;
+  const data = await response.json();
+  const obs = data.observations;
+  if (!obs || obs.length < 13) return null;
+  const current = parseFloat(obs[0].value);
+  const previous = parseFloat(obs[12].value);
+  const yoy = ((current - previous) / previous) * 100;
+  return { date: obs[0].date, value: yoy.toFixed(1) + '%' };
+}
+
+export async function getEconomicIndicators(): Promise<Indicator[]> {
+  if (!FRED_API_KEY) return [];
+  const [gdpData, cpiData, unemploymentData] = await Promise.all([
+    fetchIndicator('GDP'),
+    fetchCpiYearOverYear(),
+    fetchIndicator('UNRATE')
+  ]);
+
+  const indicators: Indicator[] = [];
+  if (gdpData) {
+    const gdpValue = (parseFloat(gdpData.value) / 1000).toFixed(2) + 'T';
+    indicators.push({ name: 'GDP (Quarterly)', value: gdpValue, date: gdpData.date });
+  }
+  if (cpiData) {
+    indicators.push({ name: 'CPI Inflation Rate', value: cpiData.value, date: cpiData.date });
+  }
+  if (unemploymentData) {
+    indicators.push({ name: 'Unemployment Rate', value: unemploymentData.value + '%', date: unemploymentData.date });
+  }
+
+  return indicators;
+}


### PR DESCRIPTION
## Summary
- move economic indicators fetching logic into a shared server utility
- make EconomicIndicators a server component
- lazy-load PriceChart to reduce initial JS size

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68532b97e394832e9408a11562ef47d2